### PR TITLE
Fix a bug that could sometimes lead to fatal assert, aborting the pro…

### DIFF
--- a/eva/vqec-dp/outputshim/vqec_sink_api.h
+++ b/eva/vqec-dp/outputshim/vqec_sink_api.h
@@ -262,7 +262,7 @@ vqec_sink_read_internal (struct vqec_sink_ *sink,
 #ifdef HAVE_FCC
     if(pak->type == VQEC_PAK_TYPE_APP) {
         VQEC_DP_ASSERT_FATAL(iobuf->buf_wrlen == 0,
-                             "buffer write length is 0");
+                             "buffer write length is not 0");
         iobuf->buf_flags |= VQEC_DP_BUF_FLAGS_APP;
     }
 #endif /* HAVE_FCC */

--- a/eva/vqec-dp/outputshim/vqec_sink_common.c
+++ b/eva/vqec-dp/outputshim/vqec_sink_common.c
@@ -234,6 +234,11 @@ int32_t vqec_sink_read (struct vqec_sink_ *sink,
             break;
         }
 
+        if (iobuf->buf_wrlen != 0 && pak_hdr->pak->type == VQEC_PAK_TYPE_APP) {
+            /* Never deQ an APP packet if the iobuf is not empty */
+	    break;
+	}
+	
         /* only deQ when enough room to copy packet */
         if ((iobuf->buf_len - iobuf->buf_wrlen) >= 
             vqec_pak_get_content_len(pak_hdr->pak)) {


### PR DESCRIPTION
…gram

If allowing the vqec_sink_read function to call vqec_sink_read_internal with packet type VQEC_PAK_TYPE_APP and at the same time pak.type is VQEC_PAK_TYPE_APP, there will be a fatal assert and the program will abort.

I have seen this happen.